### PR TITLE
Fix for #1: don't move el when counting previous siblings

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,6 @@ var isEl = require('is-el');
  * @return {(string|boolean)} CSS selector that will return only the passed element, false if element is not valid
  */
 module.exports = function (el) {
-	// Iterator for nth-child loop
-	var i = null;
-
 	// Query parts collection
 	var s = [];
 
@@ -37,10 +34,8 @@ module.exports = function (el) {
 			// Get the element's position amongst its
 			// siblings to build an "nth-child" selector
 			} else {
-				for (i = 1; el.previousElementSibling; i++) {
-					el = el.previousElementSibling;
-				}
-				s.unshift(el.tagName.toLowerCase() + ':nth-child(' + i + ')');
+				var position = countPreviousSiblings(el) + 1;
+				s.unshift(el.tagName.toLowerCase() + ':nth-child(' + position + ')');
 			}
 			// Repeat for parent
 			el = el.parentNode;
@@ -50,3 +45,12 @@ module.exports = function (el) {
 	// Return all parts, joined
 	return s.join(' > ');
 };
+
+function countPreviousSiblings(el) {
+	var count = 0;
+	while (el.previousElementSibling) {
+		el = el.previousElementSibling;
+		count += 1;
+	}
+	return count;
+}

--- a/test/spec/test.js
+++ b/test/spec/test.js
@@ -48,4 +48,28 @@ test('should build a unique selector for any DOM element', assert => {
 	assert.end();
 });
 
+test('should handle when ancestor has mixed siblings', assert => {
+	// setup
+	const oldHtml = document.body.innerHTML;
+	document.body.innerHTML = `
+		<div>
+			<h2>header</h2>
+			<div>
+			  <span class="here"></span>
+			</div>
+		</div>
+	`;
+
+	const element = document.querySelector('.here');
+
+	const selector = getSelector(element);
+
+	assert.equal(selector, 'html > body > div:nth-child(1) > div:nth-child(2) > span:nth-child(1)');
+	assert.strictEqual(document.querySelector(selector), element);
+	assert.end();
+
+	// teardown
+	document.body.innerHTML = oldHtml;
+});
+
 window.close();


### PR DESCRIPTION
Added a helper function to count siblings so the main `el` doesn't get moved.

Fixes #1